### PR TITLE
Towards allowing arbitrary input types in autocontext

### DIFF
--- a/ilastik/applets/pixelClassification/opPixelClassification.py
+++ b/ilastik/applets/pixelClassification/opPixelClassification.py
@@ -69,8 +69,7 @@ class OpPixelClassification( Operator ):
     PredictionsFromDisk = InputSlot(optional=True, level=1)
 
     PredictionProbabilities = OutputSlot(level=1) # Classification predictions (via feature cache for interactive speed)
-    PredictionProbabilitiesUint8 = OutputSlot(level=1) # Same thing, but converted to uint8 first
-    PredictionProbabilitiesUint16 = OutputSlot(level=1) # Same thing, but converted to uint16 first
+    PredictionProbabilitiesAutocontext = OutputSlot(level=1)
 
     PredictionProbabilityChannels = OutputSlot(level=2) # Classification predictions, enumerated by channel
     SegmentationChannels = OutputSlot(level=2) # Binary image of the final selections.
@@ -147,6 +146,7 @@ class OpPixelClassification( Operator ):
 
         # Hook up the prediction pipeline inputs
         self.opPredictionPipeline = OpMultiLaneWrapper( OpPredictionPipeline, parent=self )
+        self.opPredictionPipeline.InputImage.connect( self.InputImages )
         self.opPredictionPipeline.FeatureImages.connect( self.FeatureImages )
         self.opPredictionPipeline.CachedFeatureImages.connect( self.CachedFeatureImages )
         self.opPredictionPipeline.Classifier.connect( self.classifier_cache.Output )
@@ -175,8 +175,7 @@ class OpPixelClassification( Operator ):
 
         # Prediction pipeline outputs -> Top-level outputs
         self.PredictionProbabilities.connect( self.opPredictionPipeline.PredictionProbabilities )
-        self.PredictionProbabilitiesUint8.connect( self.opPredictionPipeline.PredictionProbabilitiesUint8 )
-        self.PredictionProbabilitiesUint16.connect( self.opPredictionPipeline.PredictionProbabilitiesUint16 )
+        self.PredictionProbabilitiesAutocontext.connect( self.opPredictionPipeline.PredictionProbabilitiesAutocontext )
         self.CachedPredictionProbabilities.connect( self.opPredictionPipeline.CachedPredictionProbabilities )
         self.HeadlessPredictionProbabilities.connect( self.opPredictionPipeline.HeadlessPredictionProbabilities )
         self.HeadlessUint8PredictionProbabilities.connect( self.opPredictionPipeline.HeadlessUint8PredictionProbabilities )
@@ -498,15 +497,16 @@ class OpPredictionPipeline(OpPredictionPipelineNoCache):
     """
     This operator extends the cacheless prediction pipeline above with additional outputs for the GUI.
     (It uses caches for these outputs, and has an extra input for cached features.)
-    """
+    """        
+    # we need access to the input image in order to determine data-type -> autocontext
+    InputImage = InputSlot()
     FreezePredictions = InputSlot()
     CachedFeatureImages = InputSlot()
 
     PredictionProbabilities = OutputSlot()
     CachedPredictionProbabilities = OutputSlot()
 
-    PredictionProbabilitiesUint8 = OutputSlot()
-    PredictionProbabilitiesUint16 = OutputSlot()
+    PredictionProbabilitiesAutocontext = OutputSlot()
 
     PredictionProbabilityChannels = OutputSlot( level=1 )
     SegmentationChannels = OutputSlot( level=1 )
@@ -524,19 +524,10 @@ class OpPredictionPipeline(OpPredictionPipelineNoCache):
         self.predict.LabelsCount.connect( self.NumClasses )
         self.PredictionProbabilities.connect( self.predict.PMaps )
 
-        # Alternate headless output: u == Falseint8 instead of float.
-        # Note that drange is automatically updated.
-        self.opConvertToUint8 = OpPixelOperator( parent=self )
-        self.opConvertToUint8.Input.connect( self.predict.PMaps )
-        self.opConvertToUint8.Function.setValue( lambda a: (255*a).astype(numpy.uint8) )
-        self.PredictionProbabilitiesUint8.connect( self.opConvertToUint8.Output )
-
-        # Alternate headless output: uint8 instead of float.
-        # Note that drange is automatically updated.
-        self.opConvertToUint16 = OpPixelOperator( parent=self )
-        self.opConvertToUint16.Input.connect( self.predict.PMaps )
-        self.opConvertToUint16.Function.setValue( lambda a: (65535*a).astype(numpy.uint16) )
-        self.PredictionProbabilitiesUint16.connect( self.opConvertToUint16.Output )
+        # Prepare operator for Autocontext
+        self.opConvertPMapsToInputPixelType = OpPixelOperator( parent=self )
+        self.opConvertPMapsToInputPixelType.Input.connect( self.predict.PMaps )
+        self.PredictionProbabilitiesAutocontext.connect( self.opConvertPMapsToInputPixelType.Output )
 
         # Prediction cache for the GUI
         self.prediction_cache_gui = OpSlicedBlockedArrayCache( parent=self )
@@ -573,6 +564,13 @@ class OpPredictionPipeline(OpPredictionPipelineNoCache):
         self.UncertaintyEstimate.connect( self.opUncertaintyCache.Output )
 
     def setupOutputs(self):
+        input_dtype = self.InputImage.meta.dtype
+        if isinstance(input_dtype, numpy.dtype):
+            input_dtype = input_dtype.type
+        dtype_info = np.iinfo(input_dtype)
+        self.opConvertPMapsToInputPixelType.Function.setValue(
+            lambda a: ((dtype_info.max - dtype_info.min) * a - dtype_info.min).astype(input_dtype)
+        )
         # Set the blockshapes for each input image separately, depending on which axistags it has.
         axisOrder = [ tag.key for tag in self.FeatureImages.meta.axistags ]
 
@@ -601,7 +599,7 @@ class OpPredictionPipeline(OpPredictionPipelineNoCache):
         self.prediction_cache_gui.BlockShape.setValue( (blockShapeX, blockShapeY, blockShapeZ) )
         self.opUncertaintyCache.BlockShape.setValue( (blockShapeX, blockShapeY, blockShapeZ) )
 
-        assert self.opConvertToUint8.Output.meta.drange == (0,255)
+        assert self.opConvertPMapsToInputPixelType.Output.meta.drange == self.InputImage.meta.drange
 
 class OpEnsembleMargin(Operator):
     """

--- a/ilastik/workflows/newAutocontext/newAutocontextWorkflow.py
+++ b/ilastik/workflows/newAutocontext/newAutocontextWorkflow.py
@@ -279,17 +279,15 @@ class NewAutocontextWorkflowBase(Workflow):
             #opDownstreamClassify.LabelInputs.connect( opUpstreamClassify.LabelInputs )
 
             # Connect data path
-            #assert opData.Image.meta.dtype == numpy.uint8, "Raw Data must be uint8, not {}".format( opData.Image.meta.dtype )
+            assert opData.Image.meta.dtype == opUpstreamClassify.PredictionProbabilitiesAutocontext.meta.dtype, (
+                "Probability dtype needs to match up with input image dtype, got: "
+                f"input: {opData.Image.meta.dtype} "
+                f"probabilities: {opUpstreamClassify.PredictionProbabilitiesAutocontext.meta.dtype}"
+            )
             opStacker = OpMultiArrayStacker(parent=self)
             opStacker.Images.resize(2)
             opStacker.Images[0].connect( opData.Image )
-            if opData.Image.meta.dtype == np.uint8:
-                opStacker.Images[1].connect( opUpstreamClassify.PredictionProbabilitiesUint8 )
-            else:
-                opStacker.Images[1].connect( opUpstreamClassify.PredictionProbabilitiesUint16 )
-
-
-
+            opStacker.Images[1].connect( opUpstreamClassify.PredictionProbabilitiesAutocontext )
             opStacker.AxisFlag.setValue('c')
 
             opDownstreamFeatures.InputImage.connect( opStacker.Output )


### PR DESCRIPTION
Heyo,

I had a look at your [PR to ilastik](https://github.com/ilastik/ilastik/pull/1906) and it really had anything you needed to add this new datatype. However, I tried to make it a bit more general. So right now (say, if one were to modify the `checkConstraints`) one could feed in any integer type image. What I did to achieve this:

* add a general output for autocontext: `PredictionProbabilitiesAutocontext`
* added an input slot for the input image, in order to access it's pixel properties
* setup the dtype conversion in `setupOutputs` (this function get's called once all the inputs are connected and ready -> `dtype` is known.

I guess, what's left to do is to handle floating point images, making sure to rescale to 0...1 
